### PR TITLE
fix: wrap values of variables in '' when passing them to $GITHUB_OUTPUT

### DIFF
--- a/.github/actions/npm-metagen/action.yml
+++ b/.github/actions/npm-metagen/action.yml
@@ -23,7 +23,7 @@ runs:
     run: |-
       pushd ${{ inputs.path }}
       pushd $(dirname ${{ inputs.spec }})
-      packjson=$(npm pack --pack-destination ${{ inputs.outdir }} --json --dry-run)
+      packjson=$(npm pack --pack-destination ${{ inputs.outdir }} --json --dry-run | jq -cM)
       filename=$(echo ${packjson} | jq -e ".[0].filename" -r)
       files=$(echo ${packjson}    | jq -e ".[0].files[].path" -r)
 

--- a/.github/actions/npm-metagen/action.yml
+++ b/.github/actions/npm-metagen/action.yml
@@ -33,7 +33,7 @@ runs:
 
       echo "package=${filename}" >> $GITHUB_OUTPUT
       echo "package_full=${{ inputs.outdir }}/${filename}" >> $GITHUB_OUTPUT
-      echo "packjson=${packjson}" >> $GITHUB_OUTPUT
+      echo "packjson=\'${packjson}\'" >> $GITHUB_OUTPUT
       echo "files=${files}" >> $GITHUB_OUTPUT
       popd
       popd

--- a/.github/actions/npm-metagen/action.yml
+++ b/.github/actions/npm-metagen/action.yml
@@ -34,7 +34,7 @@ runs:
       echo "package=${filename}" >> $GITHUB_OUTPUT
       echo "package_full=${{ inputs.outdir }}/${filename}" >> $GITHUB_OUTPUT
       echo "packjson=\'${packjson}\'" >> $GITHUB_OUTPUT
-      echo "files=${files}" >> $GITHUB_OUTPUT
+      echo "files=\'${files}\'" >> $GITHUB_OUTPUT
       popd
       popd
   - shell: bash

--- a/.github/actions/npm-pack/action.yml
+++ b/.github/actions/npm-pack/action.yml
@@ -41,7 +41,7 @@ runs:
     run: |-
       pushd ${{ inputs.path }}
       pushd $(dirname ${{ inputs.spec }})
-      packjson=$(npm pack --pack-destination ${{ inputs.outdir }} --json)
+      packjson=$(npm pack --pack-destination ${{ inputs.outdir }} --json | jq -cM)
       filename=$(echo ${packjson} | jq -e ".[0].filename" -r)
       ls ${{ inputs.outdir }}/${filename}
       echo "package=${filename}" >> $GITHUB_OUTPUT

--- a/.github/actions/npm-pack/action.yml
+++ b/.github/actions/npm-pack/action.yml
@@ -56,5 +56,5 @@ runs:
       pushd ${{ inputs.path }}
       contents=$(tar tvf ${{ steps.npm-pack.outputs.package_full }})
       echo ${contents}
-      echo "contents=${contents}" >> $GITHUB_OUTPUT
+      echo "contents=\'${contents}\'" >> $GITHUB_OUTPUT
       popd

--- a/.github/actions/npm-pack/action.yml
+++ b/.github/actions/npm-pack/action.yml
@@ -47,6 +47,7 @@ runs:
       echo "package=${filename}" >> $GITHUB_OUTPUT
       echo "package_full=${{ inputs.outdir }}/${filename}" >> $GITHUB_OUTPUT
       echo "packjson=\'${packjson}\'" >> $GITHUB_OUTPUT
+      echo "files=\'${files}\'" >> $GITHUB_OUTPUT
       popd
       popd
   - id: list-contents

--- a/.github/actions/npm-pack/action.yml
+++ b/.github/actions/npm-pack/action.yml
@@ -46,7 +46,7 @@ runs:
       ls ${{ inputs.outdir }}/${filename}
       echo "package=${filename}" >> $GITHUB_OUTPUT
       echo "package_full=${{ inputs.outdir }}/${filename}" >> $GITHUB_OUTPUT
-      echo "packjson=${packjson}" >> $GITHUB_OUTPUT
+      echo "packjson=\'${packjson}\'" >> $GITHUB_OUTPUT
       popd
       popd
   - id: list-contents


### PR DESCRIPTION
- refactor ('npm-metagen' action): compact JSON output passed to $packjson via jq -cM
- refactor ('npm-pack' action): compact JSON output passed to $packjson via jq -cM
- fix ('npm-metagen' action): wrap value of $packjson in '' when passing it to $GITHUB_OUTPUT
- fix ('npm-pack' action): wrap value of $packjson in '' when passing it to $GITHUB_OUTPUT
- fix ('npm-metagen' action): wrap value of $files in '' when passing it to $GITHUB_OUTPUT
- fix ('npm-pack' action): wrap value of $files in '' when passing it to $GITHUB_OUTPUT
- fix ('npm-pack' action): wrap value of $contents in '' when passing it to $GITHUB_OUTPUT
