### PR TITLE
fix: do not use high-commas for space-separated values

### DIFF
--- a/.github/actions/npm-metagen/action.yml
+++ b/.github/actions/npm-metagen/action.yml
@@ -34,7 +34,7 @@ runs:
       echo "package=${filename}" >> $GITHUB_OUTPUT
       echo "package_full=${{ inputs.outdir }}/${filename}" >> $GITHUB_OUTPUT
       echo "packjson='${packjson}'" >> $GITHUB_OUTPUT
-      echo "files='${files}'" >> $GITHUB_OUTPUT
+      echo "files=${files}" >> $GITHUB_OUTPUT
       popd
       popd
   - shell: bash

--- a/.github/actions/npm-pack/action.yml
+++ b/.github/actions/npm-pack/action.yml
@@ -62,5 +62,5 @@ runs:
       pushd ${{ inputs.path }}
       contents=$(echo $(tar tf ${{ steps.npm-pack.outputs.package_full }}))
       echo ${contents}
-      echo "contents='${contents}'" >> $GITHUB_OUTPUT
+      echo "contents=${contents}" >> $GITHUB_OUTPUT
       popd

--- a/.github/actions/npm-pack/action.yml
+++ b/.github/actions/npm-pack/action.yml
@@ -53,7 +53,7 @@ runs:
       echo "package=${filename}" >> $GITHUB_OUTPUT
       echo "package_full=${{ inputs.outdir }}/${filename}" >> $GITHUB_OUTPUT
       echo "packjson='${packjson}'" >> $GITHUB_OUTPUT
-      echo "files='${files}'" >> $GITHUB_OUTPUT
+      echo "files=${files}" >> $GITHUB_OUTPUT
       popd
       popd
   - id: list-contents


### PR DESCRIPTION
- fix ('npm-metagen' action): do not use high-commas to wrap $files values
- fix ('npm-pack' action): do not use high-commas to wrap $files values
- fix ('npm-pack' action): do not use high-commas to wrap $contents values
