### PR TITLE
fix ('npm-publish' action): evaluate variable inputs.dry-run

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -28,7 +28,7 @@ runs:
       Push-Location ${{ inputs.path }}
       Push-Location (Split-Path -Path ${{ inputs.spec }})
 
-      $dryrun = @(if (true) {echo '--dry-run'} else {echo ''})
+      $dryrun = @(if (${{ inputs.dry-run }}) {echo '--dry-run'} else {echo ''})
       Write-Output "dryrun: $dryrun"
 
       npm publish --access ${{ inputs.access }} --verbose $dryrun


### PR DESCRIPTION
reason: it generally works better when evaluating the correct variable,
makes result less predictable
