### PR TITLE
fix ('npm-publish' action): prefix condition value inputs.dry-run with $

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -28,7 +28,7 @@ runs:
       Push-Location ${{ inputs.path }}
       Push-Location (Split-Path -Path ${{ inputs.spec }})
 
-      $dryrun = @(if (${{ inputs.dry-run }}) {echo '--dry-run'} else {echo ''})
+      $dryrun = if ($${{ inputs.dry-run }}) {'--dry-run'} else {''}
       Write-Output "dryrun: $dryrun"
 
       npm publish --access ${{ inputs.access }} --verbose $dryrun


### PR DESCRIPTION
reason: $true and $false can be evaluated in Powershell
