### PR TITLE
refactor ('npm-publish' actions): split registry into scopeless URL before passing to 'npm publish'

### DIFF
--- a/.github/actions/npm-publish-package/action.yml
+++ b/.github/actions/npm-publish-package/action.yml
@@ -34,6 +34,7 @@ runs:
       Write-Output "dryrun: $dryrun"
 
       $registry = "${{ inputs.registry }}".ToLower()
+      $registryUrl = $registry.Split("@")[0]
       $package  = "${{ inputs.package }}"
 
       if ([string]::IsNullOrEmpty($package))
@@ -44,7 +45,7 @@ runs:
       Write-Output "publishing $package to $registry"
 
       cat .npmrc
-      Write-Output "npm publish $package --access=${{ inputs.access }} --verbose $dryrun --registry=$registry"
-      npm publish $package --access=${{ inputs.access }} --verbose $dryrun --registry=$registry
+      Write-Output "npm publish $package --access=${{ inputs.access }} --verbose $dryrun --registry=$registryUrl"
+      npm publish $package --access=${{ inputs.access }} --verbose $dryrun --registry=$registryUrl
 
       Pop-Location

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -34,11 +34,12 @@ runs:
       cat ${{ inputs.spec }} | jq
       cat ${{ inputs.spec }} | jq -r '.publishConfig.registry'
       $registry=(cat ${{ inputs.spec }} | jq -r '.publishConfig.registry')
+      $registryUrl = $registry.Split("@")[0]
       Write-Output "publishing to ${registry}"
 
       cat .npmrc
-      Write-Output "npm publish --access=${{ inputs.access }} --verbose $dryrun --registry=$registry"
-      npm publish --access=${{ inputs.access }} --verbose $dryrun --registry=$registry
+      Write-Output "npm publish --access=${{ inputs.access }} --verbose $dryrun --registry=$registryUrl"
+      npm publish --access=${{ inputs.access }} --verbose $dryrun --registry=$registryUrl
 
       Pop-Location
       Pop-Location


### PR DESCRIPTION
- **refactor ('npm-publish' action): split registry into scopeless URL before passing to 'npm publish'**
- **refactor ('npm-publish-package' action): split registry into scopeless URL before passing to 'npm publish'**
