### PR TITLE
refactor ('npm-publish' action): remove registry url extraction from spec and setting to npm command

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -1,4 +1,6 @@
-name: npm-publish
+name: [NPM] Publish
+description: Builds and publishes a package given its specfile (package.json)
+
 inputs:
   path:
     description: path from where to run the actions

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -20,7 +20,9 @@ inputs:
   dry-run:
     description: whether to perform a dry-run
     type: boolean
+    required: false
     default: false
+
 runs:
   using: composite
   steps:

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -26,29 +26,29 @@ inputs:
 runs:
   using: composite
   steps:
-  - id: npm-publish
+  - name: 'NPM Publish'
+    id: npm-publish
     shell: pwsh
     run: |-
       Push-Location ${{ inputs.path }}
       Push-Location (Split-Path -Path ${{ inputs.spec }})
 
-      cat ${{ inputs.spec }} | jq
-      cat ${{ inputs.spec }} | jq -r '.publishConfig.registry'
-      $registry=(cat ${{ inputs.spec }} | jq -r '.publishConfig.registry')
-      $registryUrl = $registry.Split("@")[0]
-      Write-Output "publishing to ${registry}"
+      $spec = (Split-Path -Path ${{ inputs.spec }} -Leaf -Resolve)
+      if ([string]::IsNullOrEmpty($spec))
+      {
+        throw 'No spec file provided'
+      }
 
       cat .npmrc
       if ($${{ inputs.dry-run }})
       {
-        Write-Output "npm publish --access=${{ inputs.access }} --verbose --dry-run --registry=$registryUrl"
-        npm publish --access=${{ inputs.access }} --verbose --dry-run --registry=$registryUrl
+        echo "npm publish --access=${{ inputs.access }} --verbose --dry-run"
+        npm publish --access=${{ inputs.access }} --verbose --dry-run
       }
       else
       {
-        Write-Output "npm publish --access=${{ inputs.access }} --verbose --registry=$registryUrl"
-        npm publish --access=${{ inputs.access }} --verbose --registry=$registryUrl
-
+        echo "npm publish --access=${{ inputs.access }} --verbose"
+        npm publish --access=${{ inputs.access }} --verbose
       }
 
       Pop-Location


### PR DESCRIPTION
- **refactor ('npm-publish' action): improve name and description**
- **refactor ('npm-publish' action): mark input 'dry-run' explicitly as not required**
- **refactor ('npm-publish' action): remove registry url extraction from spec and setting to npm command**
