### PR TITLE
refactor ('npm-patch-spec-registry' action): adapt step logic to work with inputs.scope being empty, containing '@' or not containing '@'

### DIFF
--- a/.github/actions/npm-patch-spec-registry/action.yml
+++ b/.github/actions/npm-patch-spec-registry/action.yml
@@ -32,7 +32,15 @@ runs:
       file: ${{ inputs.spec }}
       element: '.publishConfig.registry'
       value: ${{ inputs.registry-url }}${{ inputs.scope }}
-  - if: ${{ !contains(inputs.scope, '@') }}
+  - if: ${{ !contains(inputs.scope, '@') && inputs.scope == '' }}
+    name: 'Apply (scope is empty)'
+    uses: kagekirin/gha-utils/.github/actions/json-patch-string@main
+    with:
+      path: ${{ inputs.path }}
+      file: ${{ inputs.spec }}
+      element: '.publishConfig.registry'
+      value: ${{ inputs.registry-url }}
+  - if: ${{ !contains(inputs.scope, '@') && inputs.scope != '' }}
     name: 'Apply (scope does not contain @)'
     uses: kagekirin/gha-utils/.github/actions/json-patch-string@main
     with:

--- a/.github/actions/npm-patch-spec-registry/action.yml
+++ b/.github/actions/npm-patch-spec-registry/action.yml
@@ -24,7 +24,16 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Apply
+  - if: ${{ contains(inputs.scope, '@') }}
+    name: 'Apply (scope contains @)'
+    uses: kagekirin/gha-utils/.github/actions/json-patch-string@main
+    with:
+      path: ${{ inputs.path }}
+      file: ${{ inputs.spec }}
+      element: '.publishConfig.registry'
+      value: ${{ inputs.registry-url }}${{ inputs.scope }}
+  - if: ${{ !contains(inputs.scope, '@') }}
+    name: 'Apply (scope does not contain @)'
     uses: kagekirin/gha-utils/.github/actions/json-patch-string@main
     with:
       path: ${{ inputs.path }}


### PR DESCRIPTION
- **refactor ('npm-patch-spec-registry' action): adapt step logic to work with inputs.scope containing '@' and without '@'**
- **refactor ('npm-patch-spec-registry' action): adapt step logic to work with empty inputs.scope**
